### PR TITLE
fix: remove outdated Canonical URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,10 +107,6 @@
 
     </style>
 
-    <!-- Canonical URL for consolidating duplicate URLs -->
-    <!-- https://support.google.com/webmasters/answer/139066?hl=en -->
-    <link rel="canonical" href="https://mobprogrammingguidebook.xyz/">
-
     <!-- The Open Graph protocol metadata http://ogp.me/ -->
     <meta property="og:title" content="Ensemble Programming Guidebook">
     <meta property="og:site_name" content="Ensemble Programming Guidebook">


### PR DESCRIPTION
- Remove outdated Canonical URL because old expired domain
   had been taken over by a domain company and filled with ads.
- Canonical URL might still be useful (later) if the website is available
   both via non-www and www URLs. At the moment of writing, it’s not.